### PR TITLE
Performance method improvement

### DIFF
--- a/docs/src/guide/log-types/performance.md
+++ b/docs/src/guide/log-types/performance.md
@@ -3,7 +3,9 @@
 ```js
 import kittylog from "kittylog";
 
-kittylog.debug("Loding data...", 1000);
+kittylog.performance("Process name");
+  // your code
+kittylog.performanceEnd("Process name");
 ```
 
 ::: details Performance Parameters
@@ -13,7 +15,6 @@ kittylog.debug("Loding data...", 1000);
 ```ts
 interface PerformanceParameters {
   action: string;
-  timeTaken: number;
 }
 ```
 

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -3,7 +3,7 @@ export { debug } from "./debug/debug";
 export { error } from "./error/error";
 export { httpResponse } from "./httpResponse/httpResponse";
 export { info } from "./info/info";
-export { performance } from "./performance/performance";
+export { performance, performanceEnd } from "./performance/performance";
 export { success } from "./success/success";
 export { table } from "./table/table";
 export { tableCSV } from "./tableCSV/tableCSV";

--- a/src/functions/performance/performance.ts
+++ b/src/functions/performance/performance.ts
@@ -1,9 +1,13 @@
 import { COLORS } from "../../constants";
 import { colorizeText } from "../../utils/colorizeText";
 
-export const performance = (action: string, timeTaken: number) => {
-  const formattedTime = timeTaken < 1000 ? `${timeTaken}ms` : `${(timeTaken / 1000).toFixed(2)}s`;
+export const performance = (action: string) => {
   const label = colorizeText("[PERFORMANCE]", COLORS.cyan);
 
-  console.log(`${label} ${action} - Time taken: ${formattedTime}`);
+  console.time(`${label} ${action}`);
+};
+
+export const performanceEnd = (action: string) => {
+  const label = colorizeText("[PERFORMANCE]", COLORS.cyan);
+  console.timeEnd(`${label} ${action}`);
 };

--- a/src/test.ts
+++ b/src/test.ts
@@ -5,3 +5,14 @@ kittylog.success("Success...");
 kittylog.warning("Warn...");
 kittylog.error("Error...");
 kittylog.error(new Error("Error..."));
+
+kittylog.performance("for loop");
+for (let i = 0; i < 100; i++) {}
+kittylog.performanceEnd("for loop");
+
+kittylog.performance("while loop");
+let i = 0;
+while (i < 100) {
+  i++;
+}
+kittylog.performanceEnd("while loop");


### PR DESCRIPTION
closes #9

Implemented the performance method to be able to measure the actual code execution time.

Fixed performance method description in docs. 

Usage example:
![Schermata del 2024-01-26 14-59-39](https://github.com/pietrodev07/kittylog/assets/56634652/9ddc9761-d0b1-4ec1-a096-cd2447507b15)

Expected output:
![Schermata del 2024-01-26 14-59-26](https://github.com/pietrodev07/kittylog/assets/56634652/a5274532-5080-4713-9362-e629a4b30cad)

